### PR TITLE
chore: remove patch-package from postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"build": "run-s build:*",
 		"test": "jest",
 		"setup": "remix setup",
-		"postinstall": "patch-package && npm run setup"
+		"postinstall": "npm run setup"
 	},
 	"keywords": [
 		"react",


### PR DESCRIPTION
it prevented the package from being installed due to patch-package being in devDependencies

could also just move patch-package to regular dependencies, so if you wanna do that instead...