### PR TITLE
fix(docs): delete server filename from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ WIP!
 ## Usage
 
 ```tsx
-// app/seo.server.ts
+// app/seo.ts
 import { initSeo } from "../src/index";
 export const { getSeo, getSeoMeta, getSeoLinks } = getSeo({
 	// Pass any SEO defaults for your site here.
@@ -19,14 +19,14 @@ export const { getSeo, getSeoMeta, getSeoLinks } = getSeo({
 });
 
 // app/root.tsx
-import { getSeo } from "~/seo.server";
+import { getSeo } from "~/seo";
 let [seoMeta, seoLinks] = getSeo();
 
 export let meta = () => ({ ...seoMeta, { whatever: "cool" } });
 export let links = () => [ ...seoLinks, { rel: "stylesheet", href: "/sick-styles.css" } ];
 
 // app/routes/some-route.tsx
-import { getSeo, getSeoMeta, getSeoLinks } from "~/seo.server";
+import { getSeo, getSeoMeta, getSeoLinks } from "~/seo";
 
 // No need for route data? Get meta and links in one call.
 let [seoMeta, seoLinks] = getSeo({


### PR DESCRIPTION
This change deletes the `.server` from the filename, on Remix `v1.1.1`

If we leave the `.server` this error will appear:

![image](https://user-images.githubusercontent.com/31737273/147536073-9a4759b4-9dc0-4d41-92d5-4c2336fdbd6f.png)

After changing the filename to `seo.ts` everything works like a charm. Furthermore, as an example of this behavior Kent C. Dodds do the same thing on his website https://github.com/kentcdodds/kentcdodds.com/blob/main/app/utils/seo.ts